### PR TITLE
Changed cursor to default after a user votes for a place

### DIFF
--- a/app/assets/stylesheets/components/_vote.scss
+++ b/app/assets/stylesheets/components/_vote.scss
@@ -18,7 +18,7 @@
   &.disabled-btn {
     color: gray;
     &:hover {
-      cursor: not-allowed;
+      cursor: default;
     }
   }
 }


### PR DESCRIPTION
### What?
Changed cursor to normal after a user upvotes or downvotes a place
### Why?
A "not allowed" cursor might be confusing
### How?
Changed cursor to default in vote.scss